### PR TITLE
bugfix(#11): mp-11-fixed-crash-on-invalid-zoom

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -317,6 +317,9 @@ export class PmTilesSource extends VectorTileSourceImpl {
             this._loaded = true;
 
             extend(this, tileJSON);
+            // fix for the corrupted tilejson
+            this.minzoom = Number.parseInt(this.minzoom.toString()) || 0;
+            this.maxzoom = Number.parseInt(this.maxzoom.toString()) || 0;
             // we set this.type after extend to avoid overwriting 
             this.tileType = tileType
 


### PR DESCRIPTION
This should address issue mentioned at #11 